### PR TITLE
도메인간 연관관계 매핑 수정

### DIFF
--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/Department.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/Department.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 부서 정보
@@ -36,8 +38,9 @@ public class Department {
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "department")
     private JobHistory jobHistory;// 직원 직급 정보
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "department")
-    private Employee employee;// 직원 정보
+
+    @OneToMany(mappedBy = "department", cascade = CascadeType.PERSIST)
+    private List<Employee> employeeList = new ArrayList<>();// 직원 정보
 
     // ** setter ** //
 
@@ -50,9 +53,6 @@ public class Department {
     public void addJobHistory(JobHistory jobHistory) {
         this.jobHistory = jobHistory;
     }
-    public void addEmployee(Employee employee) {
-        this.employee = employee;
-    }
 
     // ** 연관관계 메서드 ** //
 
@@ -60,7 +60,6 @@ public class Department {
         location.addDepartment(this);
         this.location = location;
     }
-
 
     // ** 생성 메서드 ** //
 

--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/Employee.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/Employee.java
@@ -50,7 +50,7 @@ public class Employee {
     private BigDecimal commissionPct;// 수수료 퍼센트?
     private Long managerId;// 관리번호
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "department_id")
     private Department department;// 부서
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
@@ -89,7 +89,7 @@ public class Employee {
         this.commissionPct = commissionPct;
     }
 
-    public void addManager_id(Long managerId) {
+    public void addManagerId(Long managerId) {
         this.managerId = managerId;
     }
 
@@ -97,17 +97,13 @@ public class Employee {
     // ** 연관관계 메서드 ** //
 
     public void addDepartment(Department department) {
-        department.addEmployee(this);
+        department.getEmployeeList().add(this);
         this.department = department;
     }
 
     public void addJob(Job job) {
         job.addEmployee(this);
         this.job = job;
-    }
-    public void addJobHistoryList(JobHistory jobHistory) {
-        jobHistory.addEmployee(this);
-        this.jobHistoryList.add(jobHistory);
     }
 
     // ** 생성 메서드 ** //
@@ -120,7 +116,7 @@ public class Employee {
             Date hireDate,
             BigDecimal salary,
             BigDecimal commissionPct,
-            Long manager_id,
+            Long managerId,
             Department department,
             Job job) {
 
@@ -133,7 +129,7 @@ public class Employee {
         employee.addHireDate(hireDate);
         employee.addSalary(salary);
         employee.addCommissionPct(commissionPct);
-        employee.addManager_id(manager_id);
+        employee.addManagerId(managerId);
         employee.addDepartment(department);
         employee.addJob(job);
 

--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/JobHistory.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/domain/JobHistory.java
@@ -42,7 +42,9 @@ public class JobHistory {
 
     // ** setter ** //
 
+    // ** 연관관계 메서드 ** //
     public void addEmployee(Employee employee) {
+        employee.getJobHistoryList().add(this);
         this.employee = employee;
     }
 }


### PR DESCRIPTION
## Summary
- 도메인간 연관관계 매핑 수정

## Describe your changes
- 한쪽에서만 연관관계 메서드를 정의한다
- Department와 Employe 관계
  - Employee : OneToOne -> ManyToOne, OneToMany으로 변경
  - Department : OneToOne -> OneToMany으로 변경
- JobHistory와 Employee의 연관관계 메서드 수정
- Employee의 manager_id -> managerId로 변경

## Issue number and link