### PR TITLE
QueryDSL사용 위한 configuration class 생성

### DIFF
--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/config/JPAConfig.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/config/JPAConfig.java
@@ -1,0 +1,44 @@
+package com.example.companymanagement_backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * QueryDsl 사용 위한 bean 생성
+ * writer : 이호진
+ * init : 2023.04.26
+ * updated by writer :
+ * update :
+ * description : QueryDsl 사용 위한 bean 생성위한 config
+ */
+@Configuration
+public class JPAConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    /**
+     * JPA 사용 위한 bean 생성
+     * writer : 이호진
+     * init : 2023.01.16
+     * updated by writer :
+     * update :
+     * description : queryDSL 사용할 수 있는 bean 생성
+     */
+    @Bean
+    public JPAQueryFactory createJPAQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
## Summary
- QueryDSL사용 위한 configuration class 생성
  - QueryDsl 사용을 위해서는 JPAQueryFactory 객체를 사용한다
  -  JPAQueryFactory 객체의 의존성을 Spring Container에 만들어 줘야한다.

## Describe your changes

## Issue number and link