### PR TITLE
데이터 검증 에러 메시지 폼 생성

### DIFF
--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/exception/ValidatedErrorMsg.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/exception/ValidatedErrorMsg.java
@@ -1,0 +1,28 @@
+package com.example.companymanagement_backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 클라이언트로 예외 전달 방법 2
+ * writer : 이호진
+ * init : 2023.04.26
+ * updated by writer :
+ * update :
+ * description : @Validated field error 정보 담기
+ *                                (field, message)
+ */
+@Getter
+@AllArgsConstructor
+public class ValidatedErrorMsg {
+
+    private String field; // error가 난 field
+    private String errMsg; // 검증 오류 메시지
+
+    // ** 생성 메서드** //
+    public static ValidatedErrorMsg create(String field, String errMsg) {
+
+        ValidatedErrorMsg result = new ValidatedErrorMsg(field, errMsg);
+        return result;
+    }
+}

--- a/companymanagement_backend/src/main/java/com/example/companymanagement_backend/exception/ValidatedErrorsMsg.java
+++ b/companymanagement_backend/src/main/java/com/example/companymanagement_backend/exception/ValidatedErrorsMsg.java
@@ -1,0 +1,53 @@
+package com.example.companymanagement_backend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * 클라이언트로 예외 전달 방법 3
+ * writer : 이호진
+ * init : 2023.04.26
+ * updated by writer :
+ * update :
+ * description : API 에러를 객체(json)으로 던져준다
+ *               > @Validated filed error를 넘겨준다.
+ */
+@Getter
+@AllArgsConstructor
+@Slf4j
+public class ValidatedErrorsMsg<T> {
+
+    private T errors; // validated의 필드 에러 모음
+
+    // ** 비즈니스 메서드 ** //
+    /**
+     * writer : 이호진
+     * init : 2023.04.26
+     * updated by writer :
+     * update :
+     * description : BindingResult에 의해 만들어진 error들을
+     *               클라이언트에게 알려주기
+     *
+     * comment : bindingResult는 RestControllerAdvice에서 처리 못할까?
+     */
+    public static ResponseEntity<ValidatedErrorsMsg<List<ValidatedErrorMsg>>> makeValidatedErrorsContents(BindingResult bindingResult) {
+
+        // bindingResult에 들어있는 에러 정보 담기
+        List<ValidatedErrorMsg> errors = bindingResult.getFieldErrors().stream()
+                .map(fe -> ValidatedErrorMsg.create(fe.getField(), fe.getDefaultMessage()))
+                .collect(toList());
+        // ValidatedErrorsMsg 만들기
+        ValidatedErrorsMsg<List<ValidatedErrorMsg>> result = new ValidatedErrorsMsg<>(errors);
+        // 클라이언트에게 보내주기
+        return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
+    }
+
+}


### PR DESCRIPTION
## Summary
- 데이터 검증 에러 메시지 폼 생성
  - 클라이언트가 보낸 데이터 검증 중 @Validated에 의해 에러 났을 때 사용
  - 에러가 난 field와 badRequest 코드(400) 보냄

## Describe your changes

## Issue number and link